### PR TITLE
Capitalize "PHP" in buildpack name

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/php-fpm"
   id = "paketo-buildpacks/php-fpm"
   keywords = ["php", "fpm"]
-  name = "Paketo Php FPM Buildpack"
+  name = "Paketo PHP FPM Buildpack"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

In working on the language family buildpack, I realized that all of the buildpacks have PHP fully capitalized in their names (which show up in build logs) except this buildpack. This PR changes that to be standardized.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
